### PR TITLE
VORTEX SCANS troubleshoot

### DIFF
--- a/website/docs/guides/troubleshooting.md
+++ b/website/docs/guides/troubleshooting.md
@@ -1,4 +1,4 @@
----
+troubleshooting---
 # Copyright (c) The Tachiyomi Open Source Project
 # SPDX-License-Identifier: MPL-2.0
 title: Troubleshooting


### PR DESCRIPTION
VORTEX SCANS Extension showing "HTTPS ERROR 400" even though the website is fine. Provide an update. Now shows "net::ERR_HTTP_RESPONSE_CODE_FAILURE"